### PR TITLE
Support all-day events, multi-line strings and timezones; add validation; and fix bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "chrono",
  "serde",
  "thiserror",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/example.toml
+++ b/example.toml
@@ -28,9 +28,24 @@ last_modified_on = "2024-01-04T10:00:00.00Z"
 title = "An overview of calendar generation from TOML"
 # OPTIONAL: More detailed description of this event.
 description = "Learn how to use toml-to-ical"
-# MANDATORY: Start date of this event. Expected RFC 3339 format.
+# MANDATORY: Start date of this event.
+#
+# Expected RFC 3339 format. Can also be just the date component, e.g. 2024-01-04, for all-day
+# events.
+# If `start` is a date and time then `end` probably should be too, and likewise when `start` is
+# just a date then `end` should be too.
 start = "2024-01-04T11:00:00.00Z"
-# MANDATORY: End date of this event. Expected RFC 3339 format.
+# OPTIONAL: End date of this event.
+#
+# Expected RFC 3339 format. Can also be just the date component, e.g. 2024-01-04, for all-day
+# events.
+# If `start` is a date and time then `end` probably should be too, and likewise when `start` is
+# just a date then `end` should be too.
+#
+# If not provided and `start` is just a date (with no time component), then this is an all-day
+# event on the `start` date.
+# If not provided and `start` is a date and time, then this will be a event with no duration (don't
+# do this).
 end = "2024-01-04T12:00:00.00Z"
 # OPTIONAL: Location of this event.
 location = "#calendar on Zulip"

--- a/example.toml
+++ b/example.toml
@@ -81,3 +81,35 @@ interval = 2
 count = 10
 # OPTIONAL: A date that the event repetitions should stop. Mutually exclusive with `count`.
 # until = "2025-01-01T00:00:00.00Z"
+# OPTIONAL: Seconds on which the event will recur. Must be between 0 and 60.
+# In the below example, this is at the 0th second of the minute and the 30th second of the minute.
+# by_second = [ 0, 30 ]
+# OPTIONAL: Minutes on which the event will recur. Must be between 0 and 59.
+# In the below example, this is at the 15th minute of the hour and the 45th minute of the hour.
+# by_minute = [ 15, 45 ]
+# OPTIONAL: Hours on which the event will recur. Must be between 0 and 23.
+# In the below example, this is at 3pm and 4pm.
+# by_hour = [ 15, 16 ]
+# OPTIONAL: Days of the week on which the event will recur.
+# `num` must be between -53 and 53 (excl. 0) and `day` must be one of "monday", "tuesday",
+# "wednesday", "thursday", "friday", "saturday", "sunday".
+# In the below example, this is on the first Sunday and on the second-to-last Tuesday.
+# by_day = [ { day = "sunday", num = 1 }, { day = "tuesday", num = -2 } ]
+# OPTIONAL: Days of the month on which the event will recur. Must be between -31 and 31 (excl. 0).
+# In the below example, this is on the fifth day of the month and the fifth-from-last day of the
+# month.
+# by_month_day = [ 5, -5 ]
+# OPTIONAL: Days of the year on which the event will recur. Must be between -366 and 366 (excl. 0).
+# In the below example, this is on the 100th day of the year and the 200th-from-last day of the
+# year.
+# by_year_day = [ 100, -200 ]
+# OPTIONAL: Weeks of the year on which the event will recur. Must be between 1 and 52.
+# In the below example, this is on the 12th week of the year and the 34th-from-last week of the
+# year.
+# by_week_no = [ 12, 34 ]
+# OPTIONAL: Months of the year on which the event will recur. Must be between 1 and 12.
+# In the below example, this is on the 2nd month of the year and the 4th month of the year.
+# by_month = [ 2, 4 ]
+# OPTIONAL: Day that will be considered start of the week. Must be one of "monday", "tuesday",
+# "wednesday", "thursday", "friday", "saturday", "sunday".
+# week_start = "monday"

--- a/example.toml
+++ b/example.toml
@@ -32,20 +32,17 @@ description = "Learn how to use toml-to-ical"
 #
 # Expected RFC 3339 format. Can also be just the date component, e.g. 2024-01-04, for all-day
 # events.
-# If `start` is a date and time then `end` probably should be too, and likewise when `start` is
-# just a date then `end` should be too.
+# If `start` is a date and time then `end` must be too, and likewise when `start` is just a date
+# then `end` must be too.
 start = "2024-01-04T11:00:00.00Z"
 # OPTIONAL: End date of this event.
 #
 # Expected RFC 3339 format. Can also be just the date component, e.g. 2024-01-04, for all-day
 # events.
-# If `start` is a date and time then `end` probably should be too, and likewise when `start` is
-# just a date then `end` should be too.
-#
+# If `start` is a date and time then `end` must be too, and vice versa when `start` is
+# just a date then `end` must be too.
 # If not provided and `start` is just a date (with no time component), then this is an all-day
-# event on the `start` date.
-# If not provided and `start` is a date and time, then this will be a event with no duration (don't
-# do this).
+# event on the `start` date. Must be provided if `start` is a date and time.
 end = "2024-01-04T12:00:00.00Z"
 # OPTIONAL: Location of this event.
 location = "#calendar on Zulip"
@@ -79,9 +76,8 @@ frequency = "weekly"
 # OPTIONAL: Number of 'frequency' between each event? e.g. "frequency = weekly" and
 # "interval = 2" is every other week.
 interval = 2
-# OPTIONAL: Number of times the event should repeat with the given frequency.
-# Mutually exclusive with `until` - not enforced, `until` will take priority.
+# OPTIONAL: Number of times the event should repeat with the given frequency. Mutually exclusive
+# with `until`.
 count = 10
-# OPTIONAL: A date that the event repetitions should stop.
-# Mutually exclusive with `count` - not enforced, `until` will take priority.
+# OPTIONAL: A date that the event repetitions should stop. Mutually exclusive with `count`.
 # until = "2025-01-01T00:00:00.00Z"

--- a/example.toml
+++ b/example.toml
@@ -8,8 +8,33 @@ description = "An example calendar for testing"
 # added to this calendar.
 includes = [ "example-incl.toml" ]
 
-# IMPORTANT: All datetimes are expected to be in UTC. Defining events in other timezones is not
-# currently supported.
+# OPTIONAL: Any timezones used in events must be defined.
+[[timezones]]
+# MANDATORY: Name of the timezone.
+name = "Europe/Amsterdam"
+
+# MANDATORY: Timezone offset when daylight savings time is not in effect.
+[timezones.standard]
+# Name of this timezone.
+name = "CET"
+# When this timezone takes effect.
+start = "1970-10-25T03:00:00.00"
+# When this timezone repeats.
+# In the below example, each year on the last Sunday of October.
+rule = { frequency = "yearly", by_month = [10], by_day = [ { day = "sunday", num = -1 } ] }
+# UTC offset in use when this timezone begins.
+from = "+0200"
+# UTC offset when this timezone is in use.
+to = "+0100"
+
+# MANDATORY: Timezone offset when daylight savings time is in effect.
+# Same schema as in `timezones.standard`.
+[timezones.daylight]
+name = "CEST"
+start = "1970-03-29T02:00:00.00"
+from = "+0100"
+to = "+0200"
+rule = { frequency = "yearly", by_month = [3], by_day = [ { day = "sunday", num = -1 } ] }
 
 [[events]]
 # MANDATORY: Each event have a globally unique identifier (within this calendar, including events
@@ -30,15 +55,23 @@ title = "An overview of calendar generation from TOML"
 description = "Learn how to use toml-to-ical"
 # MANDATORY: Start date of this event.
 #
-# Expected RFC 3339 format. Can also be just the date component, e.g. 2024-01-04, for all-day
-# events.
+# Expected RFC 3339 format.
+# Time component can be excluded, e.g. 2024-01-04, for all-day events.
+# Timezone can be included (must be one of the timezones defined in `timezones`):
+# e.g. `{ date = "2024-01-04T11:00:00.00", timezone = "Europe/Amsterdam" }` and
+#      `{ date = "2024-01-04", timezone = "Europe/Amsterdam" }`
+#
 # If `start` is a date and time then `end` must be too, and likewise when `start` is just a date
 # then `end` must be too.
 start = "2024-01-04T11:00:00.00Z"
 # OPTIONAL: End date of this event.
 #
-# Expected RFC 3339 format. Can also be just the date component, e.g. 2024-01-04, for all-day
-# events.
+# Expected RFC 3339 format.
+# Time component can be excluded, e.g. 2024-01-04, for all-day events.
+# Timezone can be included (must be one of the timezones defined in `timezones`):
+# e.g. `{ date = "2024-01-04T11:00:00.00", timezone = "Europe/Amsterdam" }` and
+#      `{ date = "2024-01-04", timezone = "Europe/Amsterdam" }`
+#
 # If `start` is a date and time then `end` must be too, and vice versa when `start` is
 # just a date then `end` must be too.
 # If not provided and `start` is just a date (with no time component), then this is an all-day

--- a/toml-to-ical-bin/src/main.rs
+++ b/toml-to-ical-bin/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 };
 use thiserror::Error;
 use toml::{de::Error as TomlError, from_str};
-use toml_to_ical::{Calendar, External};
+use toml_to_ical::{Calendar, External, ValidationError};
 
 #[derive(Debug, Error)]
 enum Error {
@@ -15,6 +15,8 @@ enum Error {
     OpenInput(#[from] IoError),
     #[error("Failed to deserialize input calendar description: {0}")]
     ParseInput(#[from] TomlError),
+    #[error("Failed to validate calendar description: {0}")]
+    Validation(#[from] ValidationError),
     #[error("Failed to open output: {0}")]
     OpenOutput(IoError),
     #[error("Failed to write to output: {0}")]
@@ -101,6 +103,7 @@ fn main() -> Result<(), Error> {
     let opts = Opt::parse();
 
     let calendar = Calendar::load::<Session>(&opts.input)?;
+    calendar.validate()?;
 
     let mut output = if let Some(output) = opts.output {
         Output::new(output.as_os_str())

--- a/toml-to-ical-bin/src/main.rs
+++ b/toml-to-ical-bin/src/main.rs
@@ -99,7 +99,7 @@ impl io::Write for Output {
     }
 }
 
-fn main() -> Result<(), Error> {
+fn generate() -> Result<(), Error> {
     let opts = Opt::parse();
 
     let calendar = Calendar::load::<Session>(&opts.input)?;
@@ -114,4 +114,11 @@ fn main() -> Result<(), Error> {
     write!(output, "{calendar}").map_err(Error::WriteOutput)?;
 
     Ok(())
+}
+
+fn main() {
+    if let Err(e) = generate() {
+        eprintln!("{e}");
+        std::process::exit(1);
+    }
 }

--- a/toml-to-ical/Cargo.toml
+++ b/toml-to-ical/Cargo.toml
@@ -15,3 +15,4 @@ repository = "https://github.com/rust-lang/calendar-generation"
 [dependencies]
 chrono = { version = "0.4.31", features = ["serde"] }
 serde = { version = "1.0.194", features = ["derive"] }
+thiserror = "1.0.56"

--- a/toml-to-ical/Cargo.toml
+++ b/toml-to-ical/Cargo.toml
@@ -16,3 +16,6 @@ repository = "https://github.com/rust-lang/calendar-generation"
 chrono = { version = "0.4.31", features = ["serde"] }
 serde = { version = "1.0.194", features = ["derive"] }
 thiserror = "1.0.56"
+
+[dev-dependencies]
+toml = "0.8.8"

--- a/toml-to-ical/src/lib.rs
+++ b/toml-to-ical/src/lib.rs
@@ -35,6 +35,8 @@ fn floor_char_boundary(s: &str, index: usize) -> usize {
 
 /// Fold content lines according to RFC 5545 §3.1.
 fn fold(s: String) -> String {
+    let s = s.replace('\n', "\\n");
+
     if s.as_bytes().len() < FOLD_THRESHOLD_OCTETS {
         return s;
     }

--- a/toml-to-ical/src/lib.rs
+++ b/toml-to-ical/src/lib.rs
@@ -315,7 +315,7 @@ struct Organizer {
 
 impl fmt::Display for Organizer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        folded_writeln!(f, "ORGANIZER:CN={};mailto:{}", self.name, self.email)
+        folded_writeln!(f, "ORGANIZER;CN={}:mailto:{}", self.name, self.email)
     }
 }
 

--- a/toml-to-ical/src/tests.rs
+++ b/toml-to-ical/src/tests.rs
@@ -1,0 +1,317 @@
+use crate::{
+    fold, ByDay, ByHour, ByMinute, ByMonth, ByMonthDay, BySecond, ByWeekNo, ByYearDay, Calendar,
+    Count, End, Event, RecurrenceRule, RecurrenceRules, Start, Uid, ValidationError, Weekday,
+    WeekdayNum,
+};
+
+/// Simple test of folding, check that line break and white space are inserted at 75 octets.
+#[test]
+fn folding_simple() {
+    assert_eq!(
+            fold("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbb".to_string()),
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\tbbbbbbbbbbbbbbbb"
+        );
+}
+
+/// Advanced test of folding, check that line break and white space are inserted at 75 octets in
+/// the presence of multi-byte characters (ASCII characters 128-255).
+#[test]
+fn folding_multibyte_ascii_char() {
+    assert_eq!(
+            fold("ããããããããããããããããããããããããããããããããããããããããããããããããããããããããããããããããããããããããããããêêêêêêêêêêêêêêê".to_string()),
+            "ããããããããããããããããããããããããããããããããããããã\n\tãããããããããããããããããããããããããããããããããããã\n\tãããêêêêêêêêêêêêêêê"
+        );
+}
+
+/// Advanced test of folding, check that line break and white space are inserted at 75 octets in
+/// the presence of multi-byte characters (2-byte characters from UTF-8).
+#[test]
+fn folding_multibyte_utf8_char() {
+    assert_eq!(
+            fold("ĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳŧŧŧŧŧŧŧŧŧŧŧŧŧŧŧŧ".to_string()),
+            "ĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳ\n\tĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳĳ\n\tĳĳĳŧŧŧŧŧŧŧŧŧŧŧŧŧŧŧŧ"
+        );
+}
+
+/// Advanced test of folding, where length of string is an exact multiple of the 75 octet
+/// threshold, so one fold would appear to be enough if the consider additional length added by
+/// the newline + white space isn't considered.
+#[test]
+fn folding_multiple() {
+    assert_eq!(
+            fold("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyzz".to_string()),
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n\tyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy\n\tzz"
+        )
+}
+
+// Check that duplicate UIDs are rejected.
+#[test]
+fn validation_duplicate_uid() {
+    let cal = Calendar {
+        events: vec![
+            Event {
+                uid: Uid("1".to_string()),
+                end: Some(Default::default()),
+                ..Default::default()
+            },
+            Event { uid: Uid("1".to_string()), ..Default::default() },
+        ],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::DuplicateUid("1".to_string()));
+}
+
+// Check that a zero duration event is rejected.
+#[test]
+fn validation_zero_duration_event() {
+    // Only need to use `Default::default` here because that will produce a default date for
+    // `start` and a `None` for `end`.
+    let cal = Calendar { events: vec![Event { ..Default::default() }], ..Default::default() };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::ZeroDurationEvent("".to_string()));
+}
+
+// Check that mismatched start/end types are rejected.
+#[test]
+fn validation_mismatched_start_end_types() {
+    let cal = Calendar {
+        events: vec![Event {
+            start: Start::DateTime(Default::default()),
+            end: Some(End::Date(Default::default())),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::MismatchedDateTypes("".to_string()));
+
+    let cal = Calendar {
+        events: vec![Event {
+            start: Start::Date(Default::default()),
+            end: Some(End::DateTime(Default::default())),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::MismatchedDateTypes("".to_string()));
+}
+
+// Check that mutually exclusive fields in recurrence rules are rejected.
+#[test]
+fn validation_mutually_exclusive_count_until() {
+    let cal = Calendar {
+        events: vec![Event {
+            end: Some(Default::default()),
+            recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
+                count: Some(Count(2)),
+                until: Some(Default::default()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(
+        cal.validate().unwrap_err(),
+        ValidationError::CountUntilMutuallyExclusive("".to_string())
+    );
+}
+
+// Check that invalid `by_second` in recurrence rules are rejected.
+#[test]
+fn validation_invalid_by_second() {
+    let cal = Calendar {
+        events: vec![Event {
+            end: Some(Default::default()),
+            recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
+                by_second: Some(BySecond(vec![61])),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::BySecondOutOfRange("".to_string()));
+}
+
+// Check that invalid `by_minute` in recurrence rules are rejected.
+#[test]
+fn validation_invalid_by_minute() {
+    let cal = Calendar {
+        events: vec![Event {
+            end: Some(Default::default()),
+            recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
+                by_minute: Some(ByMinute(vec![60])),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::ByMinuteOutOfRange("".to_string()));
+}
+
+// Check that invalid `by_hour` in recurrence rules are rejected.
+#[test]
+fn validation_invalid_by_hour() {
+    let cal = Calendar {
+        events: vec![Event {
+            end: Some(Default::default()),
+            recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
+                by_hour: Some(ByHour(vec![24])),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::ByHourOutOfRange("".to_string()));
+}
+
+// Check that invalid `by_day` in recurrence rules are rejected.
+#[test]
+fn validation_invalid_by_day() {
+    let cal = Calendar {
+        events: vec![Event {
+            end: Some(Default::default()),
+            recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
+                by_day: Some(ByDay(vec![WeekdayNum { day: Weekday::Monday, num: 0 }])),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::ByDayOutOfRange("".to_string()));
+
+    let cal = Calendar {
+        events: vec![Event {
+            end: Some(Default::default()),
+            recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
+                by_day: Some(ByDay(vec![WeekdayNum { day: Weekday::Monday, num: 54 }])),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::ByDayOutOfRange("".to_string()));
+}
+
+// Check that invalid `by_month_day` in recurrence rules are rejected.
+#[test]
+fn validation_invalid_by_month_day() {
+    let cal = Calendar {
+        events: vec![Event {
+            end: Some(Default::default()),
+            recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
+                by_month_day: Some(ByMonthDay(vec![0])),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::ByMonthDayOutOfRange("".to_string()));
+
+    let cal = Calendar {
+        events: vec![Event {
+            end: Some(Default::default()),
+            recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
+                by_month_day: Some(ByMonthDay(vec![32])),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::ByMonthDayOutOfRange("".to_string()));
+}
+
+// Check that invalid `by_year_day` in recurrence rules are rejected.
+#[test]
+fn validation_invalid_by_year_day() {
+    let cal = Calendar {
+        events: vec![Event {
+            end: Some(Default::default()),
+            recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
+                by_year_day: Some(ByYearDay(vec![0])),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::ByYearDayOutOfRange("".to_string()));
+
+    let cal = Calendar {
+        events: vec![Event {
+            end: Some(Default::default()),
+            recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
+                by_year_day: Some(ByYearDay(vec![367])),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::ByYearDayOutOfRange("".to_string()));
+}
+
+// Check that invalid `by_week_no` in recurrence rules are rejected.
+#[test]
+fn validation_invalid_by_week_no() {
+    let cal = Calendar {
+        events: vec![Event {
+            end: Some(Default::default()),
+            recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
+                by_week_no: Some(ByWeekNo(vec![0])),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::ByWeekNoOutOfRange("".to_string()));
+
+    let cal = Calendar {
+        events: vec![Event {
+            end: Some(Default::default()),
+            recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
+                by_week_no: Some(ByWeekNo(vec![54])),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::ByWeekNoOutOfRange("".to_string()));
+}
+
+// Check that invalid `by_week_no` in recurrence rules are rejected.
+#[test]
+fn validation_invalid_by_month() {
+    let cal = Calendar {
+        events: vec![Event {
+            end: Some(Default::default()),
+            recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
+                by_month: Some(ByMonth(vec![0])),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::ByMonthOutOfRange("".to_string()));
+
+    let cal = Calendar {
+        events: vec![Event {
+            end: Some(Default::default()),
+            recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
+                by_month: Some(ByMonth(vec![13])),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    assert_eq!(cal.validate().unwrap_err(), ValidationError::ByMonthOutOfRange("".to_string()));
+}


### PR DESCRIPTION
- All-day events work by `DTSTART`/`DTEND` having `DATE` types rather than `DATETIME` types. This involves changing our parsing so that we can parse dates without time components - which is easily done using untagged enum deserializers in serde. Then, depending on whether we parsed a `DATE` or `DATETIME`, adjust how we write a `DTSTART`/`DTEND`. `DTEND` can also be optional for single-day all-day events, so allow that.
- Multi-line strings break unfolding rules of RFC 5545, as new lines are expected to be new content lines, or start with whitespace (which would indicate that it is part of a string from the previous content line). Google Calendar's ICS output just replaces newlines with `\n` in strings and then folds as normal - so this copies that.
- Fix `ORGANIZER` output, should have had a `;` instead of a `:` when specifying the `CN` property.
- Add some simple validation checks for duplicate UIDs and things like that which are easy to check.
- Improve error reporting.
- Add support for timezones. This involves extending our support for recurrence rules so that we can repeat on specific days of the week or weeks of the month - these are necessary for defining the recurrence rules that DST will start/stop on. Then, add support for defining and emitting `VTIMEZONE` blocks, which define a timezone and how it is offset from UTC with and without DST, and when DST starts/stops. Finally, allow dates to be non-UTC.