### PR TITLE
fix: Allow `ByDay` to only specify a `Weekday`

### DIFF
--- a/toml-to-ical/src/lib.rs
+++ b/toml-to-ical/src/lib.rs
@@ -241,7 +241,11 @@ impl Calendar {
                 }
 
                 if let Some(by_day) = &rule.by_day {
-                    if by_day.0.iter().any(|s| s.num < -53 || s.num > 53 || s.num == 0) {
+                    if by_day
+                        .0
+                        .iter()
+                        .any(|s| s.num.is_some_and(|num| num < -53 || num > 53 || num == 0))
+                    {
                         return Err(ValidationError::ByDayOutOfRange(uid));
                     }
                 }
@@ -858,12 +862,16 @@ impl fmt::Display for Weekday {
 #[derive(Default, Deserialize)]
 struct WeekdayNum {
     day: Weekday,
-    num: i16,
+    num: Option<i16>,
 }
 
 impl fmt::Display for WeekdayNum {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}{}", self.num, self.day)
+        if let Some(num) = self.num {
+            write!(f, "{}{}", num, self.day)
+        } else {
+            write!(f, "{}", self.day)
+        }
     }
 }
 

--- a/toml-to-ical/src/tests.rs
+++ b/toml-to-ical/src/tests.rs
@@ -175,7 +175,7 @@ fn validation_invalid_by_day() {
         events: vec![Event {
             end: Some(Default::default()),
             recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
-                by_day: Some(ByDay(vec![WeekdayNum { day: Weekday::Monday, num: 0 }])),
+                by_day: Some(ByDay(vec![WeekdayNum { day: Weekday::Monday, num: Some(0) }])),
                 ..Default::default()
             }]),
             ..Default::default()
@@ -188,7 +188,7 @@ fn validation_invalid_by_day() {
         events: vec![Event {
             end: Some(Default::default()),
             recurrence_rules: RecurrenceRules(vec![RecurrenceRule {
-                by_day: Some(ByDay(vec![WeekdayNum { day: Weekday::Monday, num: 54 }])),
+                by_day: Some(ByDay(vec![WeekdayNum { day: Weekday::Monday, num: Some(54) }])),
                 ..Default::default()
             }]),
             ..Default::default()


### PR DESCRIPTION
When looking at the specification for `iCalendar (RFC 5545)`, I saw that you don't have to specify a number with a weekday for `BYDAY`. [I saw this in the list of examples](https://icalendar.org/iCalendar-RFC-5545/3-8-5-3-recurrence-rule.html) (search for "Weekly on Tuesday and Thursday for five weeks"). 

```quote
 DTSTART;TZID=America/New_York:19970902T090000
 RRULE:FREQ=WEEKLY;UNTIL=19971007T000000Z;WKST=SU;BYDAY=TU,TH
```

This PR makes it so you do not have to specify `num` when using `BYDAY`. 

Note: this will make the calendar for `cargo` work correctly.
