### PR TITLE
Allow folders

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -2,8 +2,11 @@
 
 set -euxo pipefail
 
-mkdir -p $2
-for path in $1/*.toml; do
-  filename=$(basename $path)
-  toml-to-ical $path -o $2/${filename%.*}.ics
+mkdir -p "$2"
+
+shopt -s globstar
+for path in "$1"/**/*.toml; do
+  filepath=${path##$1/}
+  mkdir -p $2/$(dirname "$filepath")
+  toml-to-ical $path -o $2/${filepath%.*}.ics
 done

--- a/toml-to-ical-bin/src/main.rs
+++ b/toml-to-ical-bin/src/main.rs
@@ -120,7 +120,8 @@ fn generate() -> Result<(), Error> {
     // directory, have a `parent`.
     let base_path = opts.input.parent().unwrap();
     let ctx = Session::new(base_path);
-    let calendar = Calendar::load(&ctx, &opts.input)?;
+    let input = opts.input.strip_prefix(base_path).unwrap();
+    let calendar = Calendar::load(&ctx, input)?;
     calendar.validate()?;
 
     let mut output = if let Some(output) = opts.output {


### PR DESCRIPTION
This PR makes it so that `actions.sh` can handle folders; example:
Input:
```
cargo/
    all.toml
    office-hours.toml
    team-meeting.toml
clippy.toml
```
Ouput
```
cargo/
    all.ics
    office-hours.ics
    team-meeting.ics
clippy.ics
```