### PR TITLE
Optimize release build for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,11 @@ members = [
   "toml-to-ical-bin"
 ]
 resolver = "2"
+
+[profile.release]
+opt-level = "z"
+lto = "on"
+codegen-units = 1
+panic = "abort"
+incremental = false
+strip = true


### PR DESCRIPTION
With these compile flags, running `cargo build --release` will build the smallest possible binary.

I don't know how the GH CI build this tool for local usage I like saving space when possible (and perf. are not critical).

makes sense cc: @davidtwco ?