### PR TITLE
Clarify cmd line usage

### DIFF
--- a/toml-to-ical-bin/src/main.rs
+++ b/toml-to-ical-bin/src/main.rs
@@ -28,10 +28,9 @@ enum Error {
 #[derive(Parser)]
 #[command(author, version, about)]
 struct Opt {
-    // Path to the input calendar description.
+    #[arg(short, long, help = "A .toml file describing a calendar")]
     input: PathBuf,
-    /// Specify path to write the iCalendar to [default: -]
-    #[arg(short, long)]
+    #[arg(short, long, default_value = "-", help = "Specify path to write the iCalendar to")]
     output: Option<PathBuf>,
 }
 

--- a/toml-to-ical/src/lib.rs
+++ b/toml-to-ical/src/lib.rs
@@ -540,10 +540,6 @@ impl fmt::Display for Description {
 trait DateProperty {
     fn is_date(&self) -> bool;
 
-    fn is_datetime(&self) -> bool {
-        !self.is_date()
-    }
-
     fn tz(&self) -> Option<&str>;
 
     fn has_tz(&self) -> bool {


### PR DESCRIPTION
Before It was slightly misleading, now it shows the real params accepted by the tool:
```
$ cargo run -- --help
Utility for generating iCalendar files from a list of events in TOML format

Usage: toml-to-ical [OPTIONS] --input <INPUT>

Options:
  -i, --input <INPUT>    A .toml file describing a calendar
  -o, --output <OUTPUT>  Specify path to write the iCalendar to [default: -]
  -h, --help             Print help
  -V, --version          Print version
```

In the second commit removed a function that seems to bot be used anywhere (fixes a warning on compilation)

cc: @davidtwco 

thanks