### PR TITLE
allow timezone offsets of zero

### DIFF
--- a/toml-to-ical/src/lib.rs
+++ b/toml-to-ical/src/lib.rs
@@ -458,8 +458,8 @@ impl<'de> Deserialize<'de> for TimezoneOffset {
                     return Err(err);
                 };
 
-                if hour == 0 && minute == 0 {
-                    return Err(err);
+                if hour == 0 && neg {
+                    return Err(de::Error::custom("must be `+0000`, not `-0000`"));
                 }
 
                 Ok(TimezoneOffset { neg, hour, minute })

--- a/toml-to-ical/src/tests.rs
+++ b/toml-to-ical/src/tests.rs
@@ -335,11 +335,14 @@ fn parse_tz_offset() {
         toml::from_str::<Harness>("offset = \"+1323\"").unwrap().offset,
         TimezoneOffset { neg: false, hour: 13, minute: 23 }
     );
+    assert_eq!(
+        toml::from_str::<Harness>("offset = \"+0000\"").unwrap().offset,
+        TimezoneOffset { neg: false, hour: 00, minute: 00 }
+    );
     // Invalid, no sign
     assert!(toml::from_str::<Harness>("offset = \"1323\"").is_err());
-    // Invalid, zero
+    // Invalid, zeroes can't be negative
     assert!(toml::from_str::<Harness>("offset = \"-0000\"").is_err());
-    assert!(toml::from_str::<Harness>("offset = \"+0000\"").is_err());
     // Invalid, out of range
     assert!(toml::from_str::<Harness>("offset = \"+4500\"").is_err());
     assert!(toml::from_str::<Harness>("offset = \"-1078\"").is_err());


### PR DESCRIPTION
Disallows "-0000" as per RFC 5545.