### PR TITLE
Fix TZ offset validation

### DIFF
--- a/toml-to-ical/src/lib.rs
+++ b/toml-to-ical/src/lib.rs
@@ -458,7 +458,7 @@ impl<'de> Deserialize<'de> for TimezoneOffset {
                     return Err(err);
                 };
 
-                if hour == 0 && neg {
+                if hour == 0 && minute == 0 && neg {
                     return Err(de::Error::custom("must be `+0000`, not `-0000`"));
                 }
 

--- a/toml-to-ical/src/tests.rs
+++ b/toml-to-ical/src/tests.rs
@@ -343,6 +343,8 @@ fn parse_tz_offset() {
     assert!(toml::from_str::<Harness>("offset = \"1323\"").is_err());
     // Invalid, zeroes can't be negative
     assert!(toml::from_str::<Harness>("offset = \"-0000\"").is_err());
+    // ... but can be positive
+    assert!(toml::from_str::<Harness>("offset = \"+0000\"").is_ok());
     // Invalid, out of range
     assert!(toml::from_str::<Harness>("offset = \"+4500\"").is_err());
     assert!(toml::from_str::<Harness>("offset = \"-1078\"").is_err());


### PR DESCRIPTION
commit 523e3e2cbf7bfd72a869bda52c543d150a418c73 introduced a subtle bug when validating "+0000" which we use in the [_timezones.tml](https://github.com/rust-lang/calendar/blob/6f24d7a74395a06758494eb37902d8ec36d93f7d/_timezones.toml#L83) file.

IIUC, this small patch should fix the issue and keep the validation as intended.

Thanks for a review!

r? @jieyouxu cc @davidtwco 