### PR TITLE
Handle `calendar` repo containing `xtask` in CI

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -7,6 +7,12 @@ mkdir -p "$2"
 shopt -s globstar
 for path in "$1"/**/*.toml; do
   filepath=${path##$1/}
+  filename="${path##*/}"
+  firstpath="${filepath%%/*}"
+  if test "$firstpath" = "xtask" \
+  || test "$filename" = "Cargo.toml"; then
+    continue
+  fi
   mkdir -p $2/$(dirname "$filepath")
   toml-to-ical -i $path -o $2/${filepath%.*}.ics
 done


### PR DESCRIPTION
The CI iterates over and calls `toml-to-ical` on all `.toml` files in the `calendar` repo.  However, we'd like to add an `xtask` directory to the `calendar` repo, and that directory will contain non-calendar TOML files.  We may also want a top-level `Cargo.toml` file.

To support this, let's skip any files named `Cargo.toml` (a calendar for the cargo team would be in lowercase) and a top-level directory named `xtask`.

See:

- https://github.com/rust-lang/calendar/pull/67

cc @davidtwco